### PR TITLE
fix: if already not root, don't bother

### DIFF
--- a/scripts/docker/create-user.sh
+++ b/scripts/docker/create-user.sh
@@ -1,3 +1,6 @@
+# If we aren't running as root, just exec the CMD
+[ "$(id -u)" -ne 0 ] && exec "$@"
+
 
 echo "Creating user and group..."
 


### PR DESCRIPTION
This is useful when running in environments like Kubernetes, where the orchestration system can take care of both setting your effective uid/gid, as well as filesystem permissions on the volume.