### PR TITLE
feat(geolite): add Tailscale IP detection with CGNAT range check 

### DIFF
--- a/backend/internal/service/geolite_service.go
+++ b/backend/internal/service/geolite_service.go
@@ -39,7 +39,7 @@ func (s *GeoLiteService) GetLocationByIP(ipAddress string) (country, city string
 	// Check if IP is in Tailscale's CGNAT range (100.64.0.0/10)
 	if ip := net.ParseIP(ipAddress); ip != nil {
 		if ip.To4() != nil && ip.To4()[0] == 100 && ip.To4()[1] >= 64 && ip.To4()[1] <= 127 {
-			return "Tailscale Network", "Tailscale", nil
+			return "Internal Network", "Tailscale", nil
 		}
 	}
 

--- a/backend/internal/service/geolite_service.go
+++ b/backend/internal/service/geolite_service.go
@@ -5,15 +5,18 @@ import (
 	"compress/gzip"
 	"errors"
 	"fmt"
-	"github.com/oschwald/maxminddb-golang/v2"
-	"github.com/stonith404/pocket-id/backend/internal/common"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/netip"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/oschwald/maxminddb-golang/v2"
+
+	"github.com/stonith404/pocket-id/backend/internal/common"
 )
 
 type GeoLiteService struct{}
@@ -33,6 +36,13 @@ func NewGeoLiteService() *GeoLiteService {
 
 // GetLocationByIP returns the country and city of the given IP address.
 func (s *GeoLiteService) GetLocationByIP(ipAddress string) (country, city string, err error) {
+	// Check if IP is in Tailscale's CGNAT range (100.64.0.0/10)
+	if ip := net.ParseIP(ipAddress); ip != nil {
+		if ip.To4() != nil && ip.To4()[0] == 100 && ip.To4()[1] >= 64 && ip.To4()[1] <= 127 {
+			return "Tailscale Network", "Tailscale", nil
+		}
+	}
+
 	db, err := maxminddb.Open(common.EnvConfig.GeoLiteDBPath)
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
- Added proper detection of Tailscale IPs using CGNAT range (100.64.0.0/10)

Source: https://tailscale.com/kb/1015/100.x-addresses

<img width="1263" alt="image" src="https://github.com/user-attachments/assets/257d6535-a9d3-4d0b-b708-1f21429e0171">
