### PR TITLE
docs: Add "groups" scope to the oauth2-proxy sample configuration

### DIFF
--- a/docs/proxy-services.md
+++ b/docs/proxy-services.md
@@ -45,7 +45,7 @@ upstreams="http://<service-to-be-proxied>:<port>"
 
 # Additional Configuration
 provider="oidc"
-scope = "openid email profile"
+scope = "openid email profile groups"
 
 # If you are using a reverse proxy in front of OAuth2 Proxy
 reverse_proxy = true


### PR DESCRIPTION
Adding the "groups" scope which is needed with the introduction of groups in pocket-id. Since this can be easily overseen it should be added to the example.