### PR TITLE
feat: add oidc end-session endpoint

### DIFF
--- a/backend/internal/controller/oidc_controller.go
+++ b/backend/internal/controller/oidc_controller.go
@@ -1,13 +1,15 @@
 package controller
 
 import (
+	"net/http"
+	"strings"
+
 	"github.com/gin-gonic/gin"
 	"github.com/stonith404/pocket-id/backend/internal/dto"
 	"github.com/stonith404/pocket-id/backend/internal/middleware"
 	"github.com/stonith404/pocket-id/backend/internal/service"
 	"github.com/stonith404/pocket-id/backend/internal/utils"
-	"net/http"
-	"strings"
+	"github.com/stonith404/pocket-id/backend/internal/utils/cookie"
 )
 
 func NewOidcController(group *gin.RouterGroup, jwtAuthMiddleware *middleware.JwtAuthMiddleware, fileSizeLimitMiddleware *middleware.FileSizeLimitMiddleware, oidcService *service.OidcService, jwtService *service.JwtService) {
@@ -17,6 +19,9 @@ func NewOidcController(group *gin.RouterGroup, jwtAuthMiddleware *middleware.Jwt
 	group.POST("/oidc/authorize/new-client", jwtAuthMiddleware.Add(false), oc.authorizeNewClientHandler)
 	group.POST("/oidc/token", oc.createTokensHandler)
 	group.GET("/oidc/userinfo", oc.userInfoHandler)
+
+	//End Session (Logout)
+	group.POST("/oidc/end-session", oc.endSessionHandler)
 
 	group.GET("/oidc/clients", jwtAuthMiddleware.Add(true), oc.listClientsHandler)
 	group.POST("/oidc/clients", jwtAuthMiddleware.Add(true), oc.createClientHandler)
@@ -34,6 +39,12 @@ func NewOidcController(group *gin.RouterGroup, jwtAuthMiddleware *middleware.Jwt
 type OidcController struct {
 	oidcService *service.OidcService
 	jwtService  *service.JwtService
+}
+
+func (oc *OidcController) endSessionHandler(c *gin.Context) {
+	//Add logout logic
+	cookie.AddAccessTokenCookie(c, 0, "")
+	c.Status(http.StatusNoContent)
 }
 
 func (oc *OidcController) authorizeHandler(c *gin.Context) {

--- a/backend/internal/controller/oidc_controller.go
+++ b/backend/internal/controller/oidc_controller.go
@@ -21,7 +21,7 @@ func NewOidcController(group *gin.RouterGroup, jwtAuthMiddleware *middleware.Jwt
 	group.GET("/oidc/userinfo", oc.userInfoHandler)
 
 	//End Session (Logout)
-	group.POST("/oidc/end-session", oc.endSessionHandler)
+	group.GET("/oidc/end-session", jwtAuthMiddleware.Add(false), oc.endSessionHandler)
 
 	group.GET("/oidc/clients", jwtAuthMiddleware.Add(true), oc.listClientsHandler)
 	group.POST("/oidc/clients", jwtAuthMiddleware.Add(true), oc.createClientHandler)
@@ -42,9 +42,11 @@ type OidcController struct {
 }
 
 func (oc *OidcController) endSessionHandler(c *gin.Context) {
-	//Add logout logic
+	c.Request.Method = "POST"
+	c.Redirect(http.StatusSeeOther, "/webauthn/logout")
 	cookie.AddAccessTokenCookie(c, 0, "")
 	c.Status(http.StatusNoContent)
+	c.Redirect(http.StatusTemporaryRedirect, "/login")
 }
 
 func (oc *OidcController) authorizeHandler(c *gin.Context) {

--- a/frontend/src/routes/settings/admin/oidc-clients/[id]/+page.svelte
+++ b/frontend/src/routes/settings/admin/oidc-clients/[id]/+page.svelte
@@ -27,6 +27,7 @@
 		'Token URL': `https://${$page.url.hostname}/api/oidc/token`,
 		'Userinfo URL': `https://${$page.url.hostname}/api/oidc/userinfo`,
 		'Certificate URL': `https://${$page.url.hostname}/.well-known/jwks.json`,
+		'End Session URL': `https://${$page.url.hostname}/api/oidc/end-session`,
 		PKCE: client.pkceEnabled ? 'Enabled' : 'Disabled'
 	});
 


### PR DESCRIPTION
Related to: https://github.com/stonith404/pocket-id/issues/160

I tested and all seems to work, the endpoint i came up with was https://id.example.com/api/oidc/end-session 