### PR TITLE
fix(caddy): trusted_proxies for IPv6 enabled hosts

### DIFF
--- a/reverse-proxy/Caddyfile.trust-proxy
+++ b/reverse-proxy/Caddyfile.trust-proxy
@@ -1,11 +1,14 @@
 :{$CADDY_PORT:80} {
 	reverse_proxy /api/* http://localhost:{$BACKEND_PORT:8080} {
 		trusted_proxies 0.0.0.0/0
+		trusted_proxies ::/0
 	}
 	reverse_proxy /.well-known/* http://localhost:{$BACKEND_PORT:8080} {
 		trusted_proxies 0.0.0.0/0
+		trusted_proxies ::/0
 	}
 	reverse_proxy /* http://localhost:{$PORT:3000} {
 		trusted_proxies 0.0.0.0/0
+		trusted_proxies ::/0
 	}
 }


### PR DESCRIPTION
## Problem
Current the Caddyfile.trust-proxy config only includes 0.0.0.0/0 which only includes IPv4 proxies.

## Proposed Solution
Adding ::/0 (the equivalent of 0.0.0.0/0 for IPv6) allows for IPv6 proxies to be trusted. 

## Testing
1) Ran docker image without modification on a IPv6 host with network_mode:host and a caddy server as a reverse proxy in front of the docker container [1].  
2) Attempt login and check audit logs for IP Address
3) Modify running docker container with `trusted_proxies ::/0` and reload caddy with changed Caddyfile
4) Attempt login and check audit logs for IP Address (see screenshot)

[1] Caddy site block on IPv6 enabled host
```
auth.example.com {
	reverse_proxy localhost:8389
}
```

<img width="1008" alt="Screenshot 2025-01-29 at 10 15 21 PM" src="https://github.com/user-attachments/assets/f01d5b23-170f-4ff3-8ecc-3510f39c469e" />
 